### PR TITLE
Additional config options

### DIFF
--- a/src/directive.multi-select.js
+++ b/src/directive.multi-select.js
@@ -21,14 +21,16 @@
         onCheckAll: triggerChange,
         onUncheckAll: triggerChange,
         filter: true,
-        single: false
+        single: false,
+        placeholder: ""
       };
 
       if(iAttrs.ngMultiSelectFilter) { opts.filter = iAttrs.ngMultiSelectFilter === 'true'; }
       if(iAttrs.ngMultiSelectSingle) { opts.single = iAttrs.ngMultiSelectSingle === 'true'; }
       if(iAttrs.ngMultiSelectWidth) { opts.width = iAttrs.ngMultiSelectWidth; }
       if(iAttrs.ngMultiSelectMaxHeight) { opts.maxHeight = iAttrs.ngMultiSelectMaxHeight; }
-
+      if(iAttrs.ngMultiSelectPlaceholder) { opts.placeholder = iAttrs.ngMultiSelectPlaceholder; }
+      
       jElement.multipleSelect(opts);
 
 

--- a/src/directive.multi-select.js
+++ b/src/directive.multi-select.js
@@ -17,19 +17,27 @@
       var jElement = jQuery(iElement);
 
       var opts = {
-        onClick: triggerChange,
-        onCheckAll: triggerChange,
-        onUncheckAll: triggerChange,
         filter: true,
+        onCheckAll: triggerChange,
         single: false,
-        placeholder: ""
+        onClick: triggerChange,
+        onUncheckAll: triggerChange,
+        placeholder: '',
+        selectAll: true,
+        position: 'bottom',
+        keepOpen: false,
+        isOpen: false
       };
 
-      if(iAttrs.ngMultiSelectFilter) { opts.filter = iAttrs.ngMultiSelectFilter === 'true'; }
-      if(iAttrs.ngMultiSelectSingle) { opts.single = iAttrs.ngMultiSelectSingle === 'true'; }
-      if(iAttrs.ngMultiSelectWidth) { opts.width = iAttrs.ngMultiSelectWidth; }
-      if(iAttrs.ngMultiSelectMaxHeight) { opts.maxHeight = iAttrs.ngMultiSelectMaxHeight; }
+      if(iAttrs.ngMultiSelectFilter)      { opts.filter = iAttrs.ngMultiSelectFilter.toLowerCase() === 'true'; }
+      if(iAttrs.ngMultiSelectSingle)      { opts.single = iAttrs.ngMultiSelectSingle.toLowerCase() === 'true'; }
+      if(iAttrs.ngMultiSelectWidth)       { opts.width = iAttrs.ngMultiSelectWidth; }
+      if(iAttrs.ngMultiSelectMaxHeight)   { opts.maxHeight = iAttrs.ngMultiSelectMaxHeight; }
       if(iAttrs.ngMultiSelectPlaceholder) { opts.placeholder = iAttrs.ngMultiSelectPlaceholder; }
+      if(iAttrs.ngMultiSelectSelectAll)   { opts.selectAll = iAttrs.ngMultiSelectSelectAll.toLowerCase() === 'true'; }
+      if(iAttrs.ngMultiSelectPosition)    { opts.position = iAttrs.ngMultiSelectPosition; }
+      if(iAttrs.ngMultiSelectKeepOpen)    { opts.keepOpen = iAttrs.ngMultiSelectKeepOpen.toLowerCase() === 'true'; }
+      if(iAttrs.ngMultiSelectIsOpen)      { opts.isOpen = iAttrs.ngMultiSelectIsOpen.toLowerCase() === 'true'; }
       
       jElement.multipleSelect(opts);
 


### PR DESCRIPTION
Added additional configuration options from Wenzhixin's library:

- **ng-multi-select-select-all (boolean)**: Show 'select all' box. true/false, defaults true
- **ng-multi-select-position (string)**: Position of the dropdown menu. "top"/"bottom", defaults to bottom
- **ng-multi-select-keep-open (boolean)**: Keep dropdown open when clicking outside it. true/false, defaults false
- **ng-multi-select-is-open (boolean)**: Open dropdown on initiation. true/false, defaults false

I included the defaults in the `opts` object, but this is probably unnecessary.

I also changed...
`iAttrs.ngMultiSelectFilter === 'true'` 
to...
`iAttrs.ngMultiSelectFilter.toLowerCase() === 'true'`

I applied this to all boolean option evaluations to ensure case-matching in cases like `<select ng-multi-select-filter="TRUE">`

Readme/plunkr/demos should probably reflect these options.

Glad to contribute to this project. 

Thanks!